### PR TITLE
design: header ui 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "my-app",
 			"version": "0.1.0",
 			"dependencies": {
+				"lucide-react": "^0.464.0",
 				"next": "15.0.3",
 				"react": "19.0.0-rc-66855b96-20241106",
 				"react-dom": "19.0.0-rc-66855b96-20241106"
@@ -3982,6 +3983,15 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true
+		},
+		"node_modules/lucide-react": {
+			"version": "0.464.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.464.0.tgz",
+			"integrity": "sha512-eCx1qClbnw5qRqB2Z1AFFp71wdJXEwhPp5ii8LviyvHb7o/7eMXFiTyDHh7JpjM9BO9pC6ZUp/c7mCwwxbPIcg==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+			}
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"dependencies": {
 				"lucide-react": "^0.464.0",
 				"next": "15.0.3",
-				"react": "19.0.0-rc-66855b96-20241106",
-				"react-dom": "19.0.0-rc-66855b96-20241106"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"devDependencies": {
 				"@types/node": "^20",
@@ -3830,8 +3830,7 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -3970,7 +3969,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -4780,22 +4778,28 @@
 			]
 		},
 		"node_modules/react": {
-			"version": "19.0.0-rc-66855b96-20241106",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-66855b96-20241106.tgz",
-			"integrity": "sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.0.0-rc-66855b96-20241106",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-66855b96-20241106.tgz",
-			"integrity": "sha512-D25vdaytZ1wFIRiwNU98NPQ/upS2P8Co4/oNoa02PzHbh8deWdepjm5qwZM/46OdSiGv4WSWwxP55RO9obqJEQ==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"license": "MIT",
 			"dependencies": {
-				"scheduler": "0.25.0-rc-66855b96-20241106"
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
 			},
 			"peerDependencies": {
-				"react": "19.0.0-rc-66855b96-20241106"
+				"react": "^18.3.1"
 			}
 		},
 		"node_modules/react-is": {
@@ -4984,9 +4988,13 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.25.0-rc-66855b96-20241106",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-66855b96-20241106.tgz",
-			"integrity": "sha512-HQXp/Mnp/MMRSXMQF7urNFla+gmtXW/Gr1KliuR0iboTit4KvZRY8KYaq5ccCTAOJiUqQh2rE2F3wgUekmgdlA=="
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
+		"lucide-react": "^0.464.0",
 		"next": "15.0.3",
 		"react": "19.0.0-rc-66855b96-20241106",
 		"react-dom": "19.0.0-rc-66855b96-20241106"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 	"dependencies": {
 		"lucide-react": "^0.464.0",
 		"next": "15.0.3",
-		"react": "19.0.0-rc-66855b96-20241106",
-		"react-dom": "19.0.0-rc-66855b96-20241106"
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+import Header from "@/common/header"
+
 export default function Home() {
 	return (
-		<div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
-			<div>qqq</div>
+		<div>
+			<Header />
+			<div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
+				<div>qqq</div>
+			</div>
 		</div>
 	)
 }

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -20,8 +20,8 @@ export default function Header() {
 	}
 
 	return (
-		<div className="box-border flex h-20 w-full items-center justify-between rounded-2xl bg-slate-400 p-4 shadow-md">
-			<div className="w-fit flex-col gap-1 bg-slate-300">
+		<div className="box-border flex h-20 w-full items-center justify-between rounded-2xl p-4 shadow-md">
+			<div className="w-fit flex-col gap-1">
 				<nav className="flex items-center justify-start gap-1">
 					<Link href="/">
 						<House size={16} />
@@ -35,7 +35,7 @@ export default function Header() {
 					{thisPage === "main" || thisPage === "" ? "Dashboard" : thisPage}
 				</h4>
 			</div>
-			<div className="flex w-fit items-center bg-slate-500">
+			<div className="flex w-fit items-center">
 				<div className="flex h-10 w-fit items-center justify-center rounded-2xl border border-gray-600 bg-[#2d2d2d] px-4 focus-within:border-sky-400">
 					<label>
 						<Search color="gray" size={16} />

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -1,3 +1,3 @@
 export default function Header() {
-	return <div></div>
+	return <div className="h-10 bg-black"></div>
 }

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -1,18 +1,31 @@
 "use client"
 import { usePathname } from "next/navigation"
+import { useState } from "react"
 import Link from "next/link"
 import { Search, Slash, House, Settings, CircleUser, Bell } from "lucide-react"
 
 export default function Header() {
 	const pathName = usePathname()
 	const thisPage = pathName.split("/").pop()
+	const [searchText, setSearchText] = useState("")
+
+	const handleKeyPress = (event) => {
+		if (event.key === "Enter") {
+			console.log(`검색:${searchText}`)
+			setSearchText("")
+		}
+	}
+	const handleInputChange = (event) => {
+		setSearchText(event.target.value)
+	}
+
 	return (
 		<div className="box-border flex h-20 w-full items-center justify-between rounded-2xl bg-slate-400 p-4 shadow-md">
 			<div className="w-fit flex-col gap-1 bg-slate-300">
 				<nav className="flex items-center justify-start gap-1">
-					<House size={16}>
-						<Link href={"/"} />
-					</House>
+					<Link href="/">
+						<House size={16} />
+					</Link>
 					<Slash size={16} />
 					<span>
 						{thisPage === "main" || thisPage === "" ? "Dashboard" : thisPage}
@@ -25,17 +38,20 @@ export default function Header() {
 			<div className="flex w-fit items-center bg-slate-500">
 				<div className="flex h-10 w-fit items-center justify-center rounded-2xl border border-gray-600 bg-[#2d2d2d] px-4 focus-within:border-sky-400">
 					<label>
-						<Search color="gray" size={16} absoluteStrokeWidth />
+						<Search color="gray" size={16} />
 					</label>
 					<input
 						className="h-full w-48 border-none bg-transparent pl-3 text-white outline-none valid:placeholder-gray-500"
 						placeholder="Type here..."
+						value={searchText}
+						onChange={handleInputChange}
+						onKeyPress={handleKeyPress}
 					/>
 				</div>
 				<div className="m-2 flex w-fit items-center gap-1">
 					<CircleUser size={16} />
 					<h4 className="scroll-m-20 text-lg font-semibold tracking-tight">
-						Sign in
+						<Link href="/signin">Sign in</Link>
 					</h4>
 				</div>
 				<Settings size={16} className="m-2" />

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -36,7 +36,7 @@ export default function Header() {
 				</h4>
 			</div>
 			<div className="flex w-fit items-center">
-				<div className="flex h-10 w-fit items-center justify-center rounded-2xl border border-gray-600 bg-[#2d2d2d] px-4 focus-within:border-sky-400">
+				<div className="flex h-10 w-fit items-center justify-center rounded-2xl border border-gray-600 px-4 focus-within:border-sky-400">
 					<label>
 						<Search color="gray" size={16} />
 					</label>

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -1,7 +1,11 @@
+"use client"
+import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { Search, Slash, House, Settings, CircleUser, Bell } from "lucide-react"
 
 export default function Header() {
+	const pathName = usePathname()
+	const thisPage = pathName.split("/").pop()
 	return (
 		<div className="box-border flex h-20 w-full items-center justify-between rounded-2xl bg-slate-400 p-4 shadow-md">
 			<div className="w-fit flex-col gap-1 bg-slate-300">
@@ -10,10 +14,12 @@ export default function Header() {
 						<Link href={"/"} />
 					</House>
 					<Slash size={16} />
-					<span>Dashboard</span>
+					<span>
+						{thisPage === "main" || thisPage === "" ? "Dashboard" : thisPage}
+					</span>
 				</nav>
 				<h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
-					Dashboard
+					{thisPage === "main" || thisPage === "" ? "Dashboard" : thisPage}
 				</h4>
 			</div>
 			<div className="flex w-fit items-center bg-slate-500">

--- a/src/common/header/index.tsx
+++ b/src/common/header/index.tsx
@@ -1,3 +1,40 @@
+import Link from "next/link"
+import { Search, Slash, House, Settings, CircleUser, Bell } from "lucide-react"
+
 export default function Header() {
-	return <div className="h-10 bg-black"></div>
+	return (
+		<div className="box-border flex h-20 w-full items-center justify-between rounded-2xl bg-slate-400 p-4 shadow-md">
+			<div className="w-fit flex-col gap-1 bg-slate-300">
+				<nav className="flex items-center justify-start gap-1">
+					<House size={16}>
+						<Link href={"/"} />
+					</House>
+					<Slash size={16} />
+					<span>Dashboard</span>
+				</nav>
+				<h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+					Dashboard
+				</h4>
+			</div>
+			<div className="flex w-fit items-center bg-slate-500">
+				<div className="flex h-10 w-fit items-center justify-center rounded-2xl border border-gray-600 bg-[#2d2d2d] px-4 focus-within:border-sky-400">
+					<label>
+						<Search color="gray" size={16} absoluteStrokeWidth />
+					</label>
+					<input
+						className="h-full w-48 border-none bg-transparent pl-3 text-white outline-none valid:placeholder-gray-500"
+						placeholder="Type here..."
+					/>
+				</div>
+				<div className="m-2 flex w-fit items-center gap-1">
+					<CircleUser size={16} />
+					<h4 className="scroll-m-20 text-lg font-semibold tracking-tight">
+						Sign in
+					</h4>
+				</div>
+				<Settings size={16} className="m-2" />
+				<Bell size={16} className="m-2" />
+			</div>
+		</div>
+	)
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ export default {
 		"./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
 		"./src/components/**/*.{js,ts,jsx,tsx,mdx}",
 		"./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+		"./src/common/**/*.{js,ts,jsx,tsx,mdx}",
 	],
 	theme: {
 		extend: {


### PR DESCRIPTION
## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

- [➕ : lucide-react 추가](https://github.com/turbinecrew/turbin_electrical/commit/fc6b2c0a8e9fd134b6258c990610b62beb8a1091)
    - 이 커밋에서는  lucide-react를 추가했습니다.

- [🔧 : tailwind css를 common 폴더에 적용하는 작업](https://github.com/turbinecrew/turbin_electrical/commit/9337b86f101b0f52412e2eea533fd5bdb0497a5e)
    - common /header /index.tsx에서 tailwind css가 적용되지 않아서 tailwind.config.ts 파일의 content에 common 폴더를 추가했습니다.
    - ``` 
      content: [
		"./src/common/**/*.{js,ts,jsx,tsx,mdx}",
      ],

- [✨ : header UI 작업](https://github.com/turbinecrew/turbin_electrical/commit/741264764425422de4f03cb51cd549540cccfb22)
    - 컬러 보다는 레이아웃 위주로 ui 작업을 했습니다.
    ![image](https://github.com/user-attachments/assets/0b8be0c2-1331-405e-b7bd-75df8e785187)
    - input 영역 focus 될 시 border 컬러 변경되게 작업했습니다.
    ![image](https://github.com/user-attachments/assets/70aa75a4-2fe5-4261-92e1-16c54c756deb)
    - lucide-react에서 Search, Slash, House, Settings, CircleUser, Bell 아이콘 가져와서 작업했습니다.
    - lucide-react 형식은 다음과 같습니다.
        - `<Settings size={16} color="#ffffff" strokeWidth={1.25} absoluteStrokeWidth />`
            - absoluteStrokeWidth: disabled 시 size에 따라 선 굵기가 바뀌고, enable 하면 절대적인 굵기.. [자세한 설명은 공식 문서 참고](https://lucide.dev/guide/basics/stroke-width#absolute-stroke-width)
                - 활용 예시: `absoluteStrokeWidth={true}`로 설정하여 선 두께를 절대값으로 만들고 `strokeWidth` 속성을 사용하여 원하는 선 두께 값을 지정



- [✨ : 현재 경로에 기반한 조건부 페이지 제목 렌더링 작업](https://github.com/turbinecrew/turbin_electrical/commit/17a608871bb795af23b69340aea5f0b2c7cc346d)
    - usePathname hook을 이용해 페이지가 바뀜에 따라 헤더의 텍스트도 바뀌도록 하였습니다.
    - 참고: [usePathname  공식문서](https://nextjs.org/docs/app/api-reference/functions/use-pathname)


- [✨ : search input에 텍스트입력하고 enter 하면 콘솔에 출력하는 기능 추가](https://github.com/turbinecrew/turbin_electrical/commit/a75f854d34ef3c056490f4d3fd515e93ec70a80e)
    - `const [searchText, setSearchText] = useState("")`
    - 엔터키를 치면 input의 value인 searchText가 콘솔에 출력되도록 하였습니다.

- [🎨 : 헤더 배경 색 제거 작업](https://github.com/turbinecrew/turbin_electrical/commit/096663fbdccaff3a8e93f9bbd81d83f3e8282968)
    - 리액트 버전 변경하였습니다.
    - 헤더 영역 색을 제거하였습니다.
   
- [🎨 : 헤더 배경 색 제거 작업](https://github.com/turbinecrew/turbin_electrical/commit/f1c75d305518b8a62680234a48a8e48cb83a7241)
    - 헤더 영역 색을 제거하였습니다.
    ![image](https://github.com/user-attachments/assets/06816314-8dd8-4084-b648-40ed5e2711ae)


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
